### PR TITLE
[#3165886] Password Reset form validation is not prompted anymore

### DIFF
--- a/username_enumeration_prevention.module
+++ b/username_enumeration_prevention.module
@@ -60,9 +60,6 @@ function username_enumeration_prevention_pass_validate($form, FormStateInterface
   }
 
   $form_state->set('username_enumeration_prevention_blocked', !empty($form_state->getErrors()));
-
-  // Clear errors so they are not displayed to the end-user.
-  $form_state->clearErrors();
 }
 
 /**


### PR DESCRIPTION
Original issue - https://www.drupal.org/project/username_enumeration_prevention/issues/3165886