### PR TITLE
[#3167106] Deprecated function User::getUsername

### DIFF
--- a/username_enumeration_prevention.module
+++ b/username_enumeration_prevention.module
@@ -77,7 +77,7 @@ function username_enumeration_prevention_pass_submit($form, FormStateInterface $
     $mail = _user_mail_notify('password_reset', $account, $langcode);
     if (!empty($mail)) {
       \Drupal::logger('username_enumeration_prevention')->notice('Password reset instructions mailed to %name at %email.', [
-        '%name' => $account->getUsername(),
+        '%name' => $account->getAccountName(),
         '%email' => $account->getEmail(),
       ]);
     }


### PR DESCRIPTION
Original issue - https://www.drupal.org/project/username_enumeration_prevention/issues/3167106